### PR TITLE
Build server for parsers

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -77,6 +77,7 @@
     "babylon5": "npm:babylon@^5",
     "babylon6": "npm:babylon@^6",
     "babylon7": "npm:@babel/parser@^7",
+    "browser-env": "^3.3.0",
     "cherow": "^1.6.8",
     "codemirror": "^5.22.0",
     "codemirror-graphql": "^0.11.6",
@@ -174,7 +175,7 @@
   "scripts": {
     "start": "serve -l 8080 ../out",
     "build": "rimraf ../out/* && cross-env NODE_ENV=production webpack --mode=production",
-    "server-build": "rm -rf dist && webpack --mode development --config webpack.server.config.js",
+    "server-build": "rm -rf ./dist && webpack --mode development --config webpack.server.config.js",
     "server-start": "node ./dist/server.js",
     "build-dev": "rimraf ../out/* && cross-env NODE_ENV=development webpack -d --mode=development",
     "watch": "webpack -dw --mode=development",

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -2,6 +2,9 @@
 import {getParserByID} from './parsers';
 
 import express from 'express';
+import browserEnv from 'browser-env';
+browserEnv();
+
 const app = express()
 const port = 3300
 

--- a/website/webpack.server.config.js
+++ b/website/webpack.server.config.js
@@ -1,7 +1,24 @@
 const path = require('path')
 const webpack = require('webpack')
 const nodeExternals = require('webpack-node-externals')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const DEV = process.env.NODE_ENV !== 'production';
+
 module.exports = {
+    plugins:[
+      new webpack.NormalModuleReplacementPlugin(
+        /\.\.\/data/,
+        module => {
+          if (/css-tree/.test(module.context)) {
+            module.request += '/index.js';
+          }
+        }
+      ),
+      new MiniCssExtractPlugin({
+        filename: DEV ? '[name].css' : `[name]-[contenthash]-${CACHE_BREAKER}.css`,
+        allChunks: true,
+      }),
+    ],
     entry: {
         server: './src/server.js',
     },
@@ -23,7 +40,7 @@ module.exports = {
             /typescript\/lib/,
             /esprima\/dist\/esprima\.js/,
             /esprima-fb\/esprima\.js/,
-            /glsl/,
+            // /glsl/,
             // This is necessary because flow is trying to load the 'fs' module, but
             // dynamically. Without this webpack will throw an error at runtime.
             // I assume the `require(...)` call "succeeds" because 'fs' is shimmed to
@@ -31,6 +48,15 @@ module.exports = {
             /flow-parser\/flow_parser\.js/,
         ],
         rules: [
+          {
+            test: /\.txt$/,
+            exclude: /node_modules/,
+            loader: 'raw-loader',
+          },
+          {
+            test: /\.(sass|less|css)$/,
+            loaders: ['style-loader', 'css-loader', 'less-loader']
+          },
             {
                 test: /\.(jsx?|mjs)$/,
                 type: 'javascript/auto',
@@ -80,7 +106,7 @@ module.exports = {
                     /src\/parsers/,
                 ],
                 exclude:[
-                    /src\/parsers\/glsl/,
+                    // /src\/parsers\/glsl/,
                 ],
                 loader: 'babel-loader',
                 options: {


### PR DESCRIPTION
- Add `browser-env` to support codemirror browser function calling (using `navigator`, `window`)
- Add loaders for css code
- Remove glsl